### PR TITLE
Fix hacknehs.org link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hacknehs
-If you've ever felt a burning desire to navigate to [hacknehs.org](hacknehs.org) but are currently running IDLE instead of Google Chrome, `hacknehs` is just the package for you! It opens the website flawlessly, fearlessly, and without delay.
+If you've ever felt a burning desire to navigate to [hacknehs.org](http://hacknehs.org) but are currently running IDLE instead of Google Chrome, `hacknehs` is just the package for you! It opens the website flawlessly, fearlessly, and without delay.
 
 ## Installation
 


### PR DESCRIPTION
This mistake could prevent an innumerable amount of future Steve Jobses from finding our event—something we simply cannot afford.